### PR TITLE
1.40.0 Compatible

### DIFF
--- a/Source/EasyOffset.csproj
+++ b/Source/EasyOffset.csproj
@@ -102,6 +102,9 @@
 	<Reference Include="BeatSaber.ViewSystem">
 	  <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
 	</Reference>
+    <Reference Include="BeatSaber.GameSettings">
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.GameSettings.dll</HintPath>
+    </Reference>
     <Reference Include="BeatSaber.Settings">
       <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.Settings.dll</HintPath>
     </Reference>

--- a/Source/manifest.json
+++ b/Source/manifest.json
@@ -5,7 +5,7 @@
   "author": "Reezonate",
   "version": "2.1.13",
   "description": "Easy controller offset adjustment tool",
-  "gameVersion": "1.37.5",
+  "gameVersion": "1.40.0",
   "dependsOn": {
     "BSIPA": "^4.3.3",
     "BeatSaberMarkupLanguage": "^1.12.0",


### PR DESCRIPTION
The mod works! - this PR is mainly for that alone.


### **IMPORTANT NOTES**
It seems like all offsets have been changed **_again_**... 
- Loading a preset in game the z offset _seems_ to be the only noticeable difference so its likely this could be mitigated if you wanted that - if not maybe add another/new warning message
- The alternative handling setting also seems to affect the loaded preset and currently **does not** seem to fix the aforementioned offset issue nor make 1.29.1 presets transfer nicely
- I'd adjust dependencies as needed for when they are publicly released, currently I cloned and compiled locally. I can do that if it happens before you modify or merge :)